### PR TITLE
Avoid count classes behind after student joined in the group class

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -7,25 +7,27 @@ class Student < ApplicationRecord
 
   def count_presence(attendances, klass)
     count = 0
-
-    if self.situations.where(klass_id: klass).present?
-      count = period_attendances(attendances)
-    else
-      attendances.each do |attended|
-        count += 1 if attended.students.where(id: self.id).size == 0
-      end
-    end
-
+    count = if situations.where(klass_id: klass).present?
+              period = attendances.where("realized_at <= ?", self.situations.first.created_at)
+              period_attendances(attendances, period)
+            else
+              period = attendances.where('realized_at >= ?', self.created_at)
+              period_attendances(attendances, period)
+            end
     count
     # count = (count.to_f/attendances.size.to_f*100)
     # convert_to_percentage(count)
   end
 
-  def period_attendances(attendances)
+  def period_attendances(attendances, period)
+    # 1st scenario: the student was disabled so the next classes attendance,
+    # should not be counted.
+    # 2nd scenario: the student joined on the group days later after began
+    # the first class then we should not count the classes attendances behind
+    # the day that he joined the group klass.
     count = 0
-    period = attendances.where('realized_at <= ?', self.situations.first.created_at)
     period.each do |attended|
-      count += 1 if attended.students.where(id: self.id).size == 0
+      count += 1 if attended.students.where(id: id).empty?
     end
     count
   end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'Groups management', type: :request do
       it 'fails to create a group' do
         group = Group.new
         group.save
-        binding.pry
         # expect(response).to fail
       end
     end


### PR DESCRIPTION
- [x] 1st scenario: the student was disabled so the next classes attendance,
    should not be counted.
- [x] 2nd scenario: the student joined on the group days later after began
    the first class then we should not count the classes attendances behind
    the day that he joined the group class.