### PR TITLE
Add it Bugsnag integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.3'
 gem 'aws-sdk-s3', '~> 1'
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'bugsnag', '~> 6.12'
 gem 'coffee-rails', '~> 4.2', '>= 4.2.2'
 gem 'coveralls', require: false
 gem 'devise', '>= 4.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
+    bugsnag (6.12.1)
+      concurrent-ruby (~> 1.0)
     builder (3.2.3)
     capybara (3.28.0)
       addressable
@@ -361,6 +363,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
   bootsnap (>= 1.1.0)
+  bugsnag (~> 6.12)
   capybara (>= 3.24.0)
   chromedriver-helper (>= 2.1.1)
   coffee-rails (~> 4.2, >= 4.2.2)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,0 +1,3 @@
+Bugsnag.configure do |config|
+  config.api_key = ENV['BUGSNAG_API_KEY']
+end


### PR DESCRIPTION
### Description

This PR adds the Bugsnag integration to receive instantaneously an error that occur on the production server. 

### Changelog
* Add it Bugsnag gem
* Add it env API key directly on your server

### How to test
* Go to the console and run `Bugsnag.notify("Test error")`
* On the Bugsnag dashboard, you must see the error