### PR TITLE
Allow Admins to delete justifications

### DIFF
--- a/app/controllers/admin/justifications_controller.rb
+++ b/app/controllers/admin/justifications_controller.rb
@@ -1,35 +1,30 @@
 # frozen_string_literal: true
 
 class Admin::JustificationsController < AdminController
+  before_action :set_justification, except: %i[index new create]
+
   def index
     @justifications = Justification.all
   end
 
-  def show
-    @justification = Justification.find(params[:id])
-  end
-
   def edit
-    @justification = Justification.find(params[:id])
     render :edit
   end
 
   def update
-    @justification = Justification.find(params[:id])
     if @justification.update(justification_params)
       flash[:notice] = 'Justificativa atualizada com sucesso!'
       redirect_to admin_justifications_path
     else
       flash[:notice] = 'Algo errado aconteceu, tente novamente!'
-      redirect_to admin_justification_path(@justification)
+      render :edit
     end
   end
 
   def destroy
-    @justification = Justification.find(params[:id])
     @justification.destroy
 
-    flash['success'] = 'Attendance was removed successfully.'
+    flash[:notice] = 'Justificativa apagada com sucesso.'
     redirect_to admin_justifications_path
   end
 
@@ -37,5 +32,9 @@ class Admin::JustificationsController < AdminController
 
   def justification_params
     params.require(:justification).permit(:status)
+  end
+
+  def set_justification
+    @justification = Justification.find(params[:id])
   end
 end

--- a/app/controllers/admin/justifications_controller.rb
+++ b/app/controllers/admin/justifications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::JustificationsController < AdminController
-  before_action :set_justification, except: %i[index new create]
+  before_action :set_justification, except: %i[index]
 
   def index
     @justifications = Justification.all

--- a/app/controllers/admin/justifications_controller.rb
+++ b/app/controllers/admin/justifications_controller.rb
@@ -18,11 +18,19 @@ class Admin::JustificationsController < AdminController
     @justification = Justification.find(params[:id])
     if @justification.update(justification_params)
       flash[:notice] = 'Justificativa atualizada com sucesso!'
-      redirect_to admin_dashboard_path
+      redirect_to admin_justifications_path
     else
       flash[:notice] = 'Algo errado aconteceu, tente novamente!'
       redirect_to admin_justification_path(@justification)
     end
+  end
+
+  def destroy
+    @justification = Justification.find(params[:id])
+    @justification.destroy
+
+    flash['success'] = 'Attendance was removed successfully.'
+    redirect_to admin_justifications_path
   end
 
   private

--- a/app/models/justification.rb
+++ b/app/models/justification.rb
@@ -4,7 +4,7 @@ class Justification < ApplicationRecord
   has_attached_file :upload
 
   validates_attachment_content_type :upload, content_type: %r{\Aimage\/.*\Z}
-  validates :name, :date, :email, :description, presence: true
+  validates :name, :date, :email, :description, :status, presence: true
   enum status: {
     pendente: 'pendente',
     aceito: 'aceito',

--- a/app/views/admin/justifications/_form.html.erb
+++ b/app/views/admin/justifications/_form.html.erb
@@ -7,5 +7,6 @@
       </div>
       <%= f.submit 'Salvar', class: "btn btn-success" %>
       <%= link_to 'Voltar', :back, class: "btn btn-link" %>
+      <%= link_to 'Apagar', admin_justification_path(params[:id]), data: { confirm: 'Tem certeza?' }, method: :delete, class: "btn btn-danger" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       end
       # resources :situations
       resources :teachers
-      resources :justifications, only: %i[index show edit update]
+      resources :justifications, only: %i[index show edit update destroy]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       end
       # resources :situations
       resources :teachers
-      resources :justifications, only: %i[index show edit update destroy]
+      resources :justifications, except: %i[new create]
     end
   end
 

--- a/spec/requests/admin/justifications_spec.rb
+++ b/spec/requests/admin/justifications_spec.rb
@@ -33,16 +33,45 @@ RSpec.describe 'Admin justifications', type: :request do
   end
 
   describe '#update' do
-    it 'updates the justification status' do
-      put admin_justification_path(justifications.first.id), params: { justification: { status: 'aceito' } }
-      expect(justifications.first.status).to eq('aceito')
-      expect(response).to redirect_to admin_justifications_path
+    context 'with valid attributes' do
+      before do
+        patch admin_justification_path(justifications.first.id),
+              params: { justification: { status: 'aceito' } }
+      end
+
+      it 'changes the justification`s attribute' do
+        justifications.first.reload
+        expect(justifications.first.status).to eq('aceito')
+      end
+
+      it 'redirects to justifications#index' do
+        expect(response).to redirect_to admin_justifications_path
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'render :edit template' do
+        patch admin_justification_path(justifications.first.id),
+              params: { justification: { status: nil } }
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe '#edit' do
+    it 'renders a justification to edit template' do
+      get edit_admin_justification_path(justifications.first.id)
+      expect(response).to render_template :edit
     end
   end
 
   describe '#destroy' do
     it 'deletes a justification' do
-      delete admin_justification_path(justifications.first.id)
+      expect { delete admin_justification_path(justifications.first) }.to change(Justification, :count).by(2)
+    end
+
+    it 'redirects to justifications#index' do
+      delete admin_justification_path(justifications.first)
       expect(response).to redirect_to admin_justifications_path
     end
   end

--- a/spec/requests/admin/justifications_spec.rb
+++ b/spec/requests/admin/justifications_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin justifications', type: :request do
+  before do
+    sign_in admin
+  end
+
+  let(:admin) { create(:admin) }
+  let(:student) { create(:student) }
+  let(:justifications) { create_list(:justification, 3, email: student.email) }
+
+  describe '#index' do
+    before do
+      get admin_justifications_path
+    end
+
+    it 'renders the index template' do
+      expect(response).to render_template(:index)
+    end
+
+    it 'shows all the student justifications' do
+      expect(justifications.count).to eq(3)
+    end
+  end
+
+  describe '#show' do
+    it 'shows a justification' do
+      get admin_justification_path(justifications.first.id)
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#update' do
+    it 'updates the justification status' do
+      put admin_justification_path(justifications.first.id), params: { justification: { status: 'aceito' } }
+      expect(justifications.first.status).to eq('aceito')
+      expect(response).to redirect_to admin_justifications_path
+    end
+  end
+
+  describe '#destroy' do
+    it 'deletes a justification' do
+      delete admin_justification_path(justifications.first.id)
+      expect(response).to redirect_to admin_justifications_path
+    end
+  end
+end

--- a/spec/requests/admin/justifications_spec.rb
+++ b/spec/requests/admin/justifications_spec.rb
@@ -66,13 +66,16 @@ RSpec.describe 'Admin justifications', type: :request do
   end
 
   describe 'DELETE #destroy' do
+    before do
+      @justification = create(:justification)
+    end
+
     it 'deletes a justification' do
-      justification = create(:justification)
-      expect { justification.destroy }.to change(Justification, :count).by(-1)
+      expect { delete admin_justification_path(@justification) }.to change(Justification, :count).by(-1)
     end
 
     it 'redirects to justifications#index' do
-      delete admin_justification_path(justifications.first)
+      delete admin_justification_path(@justification)
       expect(response).to redirect_to admin_justifications_path
     end
   end

--- a/spec/requests/admin/justifications_spec.rb
+++ b/spec/requests/admin/justifications_spec.rb
@@ -65,9 +65,10 @@ RSpec.describe 'Admin justifications', type: :request do
     end
   end
 
-  describe '#destroy' do
+  describe 'DELETE #destroy' do
     it 'deletes a justification' do
-      expect { delete admin_justification_path(justifications.first) }.to change(Justification, :count).by(2)
+      justification = create(:justification)
+      expect { justification.destroy }.to change(Justification, :count).by(-1)
     end
 
     it 'redirects to justifications#index' do


### PR DESCRIPTION
### Description

This PR allows the admins to delete the student's justifications.

### Changelog
* Add a delete button inside the justification details.

### How to test
* Open the administration dashboard and click it on View/Detail or going directly to justifications page and click it on View/Detail.

### Screenshot
![image](https://user-images.githubusercontent.com/104600/65163848-18b08980-da12-11e9-82d1-5441dea8351e.png)


