### PR TITLE
Allow student and admin to change their password

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   protected
 
-  def after_update_path_for(_resource)
+  def after_update_path_for(resource)
     case resource
     when Admin
       admin_dashboard_path

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,14 @@
+class RegistrationsController < Devise::RegistrationsController
+  layout 'internal'
+
+  protected
+
+  def after_update_path_for(_resource)
+    case resource
+    when Admin
+      admin_dashboard_path
+    when Student
+      student_dashboard_path
+    end
+  end
+end

--- a/app/views/common/_top_bar_nav.html.erb
+++ b/app/views/common/_top_bar_nav.html.erb
@@ -27,11 +27,10 @@
       </a>
       <div class="dropdown-menu dropdown-menu-right profile-dropdown ">
         <!-- item-->
-        <!-- <a href="javascript:void(0);"
-           class="dropdown-item notify-item">
-          <i class="ti-user"></i>
-          <span>Minha conta</span>
-        </a> -->
+          <%= link_to url_for([:edit, :"#{user_context}", :registration]), class: 'dropdown-item notify-item' do %>
+            <i class="ti-user"></i>
+            <span>Alterar Senha</span>
+          <% end %>
 
         <!-- item-->
         <%= link_to url_for([:destroy, :"#{user_context}", :session]), class: 'dropdown-item notify-item', method: :delete do %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,7 +38,7 @@
 
             <div class="col-md-10">
               <br />
-              <%= f.label :current_password %> <i>(senha atual)</i><br />
+              <%= f.label :current_password %>
               <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
             </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,64 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-12">
+        <h4 class="m-b-20 header-title">Alterar Senha</h4>
+        <div class="row">
+          <div class="col-md-6">
+            <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+            <%= render partial: 'devise/shared/error_messages', resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+            <div class="col-md-10">
+              <%= f.label :email %><br />
+              <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', disabled: true %>
+            </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+            <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <div>Atualmente estamos aguardando a confirmação de:
+              <%= resource.unconfirmed_email %>
+            </div>
+            <% end %>
+
+            <div class="col-md-10">
+              <br />
+              <%= f.label :password %><br />
+              <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+              <% if @minimum_password_length %>
+              <br />
+              <em>
+                <%= @minimum_password_length %> caracteres mínimo</em>
+              <% end %>
+            </div>
+
+            <div class="col-md-10">
+              <br />
+              <%= f.label :password_confirmation %><br />
+              <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control' %>
+            </div>
+
+            <div class="col-md-10">
+              <br />
+              <%= f.label :current_password %> <i>(senha atual)</i><br />
+              <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
+            </div>
+
+            <div class="col-md-10">
+              <br />
+              <%= f.submit 'Salvar', class: 'btn btn-success' %>
+              <%= link_to 'Voltar', :back, class: 'btn btn-link' %>
+            </div>
+
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <!-- container -->
+    </div>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <!-- Footer -->
+  <div class="footer">
+    <%= render 'common/footer' %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+  <!-- END Footer -->
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -26,7 +26,7 @@
 
                 <div class="form-group m-b-20">
                   <div class="col-xs-12">
-                    <label for="password">Password</label>
+                    <label for="password">Senha</label>
                     <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
                   </div>
                 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,22 @@
+<% if resource.errors.any? %>
+<div class="alert alert-icon alert-danger alert-dismissible fade show"
+     role="alert">
+  <button type="button"
+          class="close"
+          data-dismiss="alert"
+          aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <i class="mdi mdi-block-helper"></i>
+  <strong>Atenção!</strong>
+  <%= I18n.t("errors.messages.not_saved",
+                     count: resource.errors.count,
+                     resource: resource.class.model_name.human.downcase)
+           %> <br />
+  <% resource.errors.full_messages.each do |message| %>
+  <li>
+    <%= message %>
+  </li>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/layouts/internal.html.erb
+++ b/app/views/layouts/internal.html.erb
@@ -15,7 +15,11 @@
   </head>
 
   <body>
-
+    <% if notice %>
+      <p class="alert alert-success"><%= notice %></p>
+    <% elsif alert %>
+      <p class="alert alert-danger"><%= alert %></p>
+    <% end %>
     <!-- Begin page -->
     <div id="wrapper">
 

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -2,7 +2,7 @@
 pt-BR:
   activerecord:
     attributes:
-      user:
+      student:
         confirmation_sent_at: Confirmação enviada em
         confirmation_token: Token de confirmação
         confirmed_at: Confirmado em
@@ -28,12 +28,20 @@ pt-BR:
         updated_at: Atualizado em
     models:
       user: Usuário
+      student: Aluno
     errors:
+      models:
+        student:
+          attributes:
+            current_password:
+              blank: em branco
+              invalid: inválida
       messages:
         record_invalid: 'A validação falhou: %{errors}'
         restrict_dependent_destroy:
           has_one: Não é possível excluir o registro pois existe um %{record} dependente
           has_many: Não é possível excluir o registro pois existem %{record} dependentes
+      invalid: Inválido
   date:
     abbr_day_names:
     - Dom

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -26,12 +26,41 @@ pt-BR:
         unconfirmed_email: E-mail não confirmado
         unlock_token: Token de desbloqueio
         updated_at: Atualizado em
+      admin:
+        confirmation_sent_at: Confirmação enviada em
+        confirmation_token: Token de confirmação
+        confirmed_at: Confirmado em
+        created_at: Criado em
+        current_password: Senha atual
+        current_sign_in_at: Atualmente logado em
+        current_sign_in_ip: IP do acesso atual
+        email: Email
+        encrypted_password: Senha criptografada
+        failed_attempts: Tentativas sem sucesso
+        last_sign_in_at: "Último acesso em"
+        last_sign_in_ip: "Último IP de acesso"
+        locked_at: Bloqueado em
+        password: Senha
+        password_confirmation: Confirme sua senha
+        remember_created_at: Lembrar criado em
+        remember_me: Lembre-se de mim
+        reset_password_sent_at: Resetar senha enviado em
+        reset_password_token: Resetar token de senha
+        sign_in_count: Contagem de acessos
+        unconfirmed_email: E-mail não confirmado
+        unlock_token: Token de desbloqueio
+        updated_at: Atualizado em
     models:
       user: Usuário
       student: Aluno
     errors:
       models:
         student:
+          attributes:
+            current_password:
+              blank: em branco
+              invalid: inválida
+        admin:
           attributes:
             current_password:
               blank: em branco

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -401,5 +401,5 @@ pt-BR:
       not_found: não encontrado
       not_locked: não foi bloqueado
       not_saved:
-        one: 'Não foi possível salvar %{resource}: 1 erro'
-        other: 'Não foi possível salvar %{resource}: %{count} erros.'
+        one: 'Não foi possível atualizar %{resource}: foi encontrado 1 erro.'
+        other: 'Não foi possível atualizar %{resource}: foram encontrados %{count} erros.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Rails.application.routes.draw do
   devise_for :students, path: 's', controllers: { sessions: 'sessions',
                                                   registrations: 'registrations',
                                                   confirmations: 'student/confirmation' }
-  devise_for :admins, path: 'a', controllers: { sessions: 'sessions' }
+  devise_for :admins, path: 'a', controllers: { sessions: 'sessions',
+                                                registrations: 'registrations'}
 
   resources :justifications, path: 'justificativa', path_names: { new: 'novo' },
                                                     only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :students, path: 's', controllers: { sessions: 'sessions',
+                                                  registrations: 'registrations',
                                                   confirmations: 'student/confirmation' }
   devise_for :admins, path: 'a', controllers: { sessions: 'sessions' }
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -6,20 +6,21 @@ RSpec.describe 'Registrations', type: :request do
 
     setup do
       sign_in student
-      @params = { params: { student: { password: 'test123',
-                                       password_confirmation: 'test123',
-                                       current_password: 'zeliotest' } } }
     end
 
     it 'checks if the password was updated' do
-      put student_registration_path, @params
+      put student_registration_path, params: { student: { password: 'test123',
+                                                          password_confirmation: 'test123',
+                                                          current_password: 'zeliotest' } }
       student.reload
       expect(student.valid_password?('test123')).to be(true)
     end
 
-    context '#after_update_path_for' do
+    context 'when #after_update_path_for' do
       it 'redirects to the current user dashboard' do
-        put student_registration_path, @params
+        put student_registration_path, params: { student: { password: 'test123',
+                                                            password_confirmation: 'test123',
+                                                            current_password: 'zeliotest' } }
         expect(response).to redirect_to student_dashboard_path
       end
     end
@@ -40,20 +41,21 @@ RSpec.describe 'Registrations', type: :request do
 
     setup do
       sign_in admin
-      @params = { params: { admin: { password: 'admin123',
-                                     password_confirmation: 'admin123',
-                                     current_password: '1234567890' } } }
     end
 
     it 'checks if the password was updated' do
-      put admin_registration_path, @params
+      put admin_registration_path, params: { admin: { password: 'admin123',
+                                                      password_confirmation: 'admin123',
+                                                      current_password: '1234567890' } }
       admin.reload
       expect(admin.valid_password?('admin123')).to be(true)
     end
 
-    context '#after_update_path_for' do
+    context 'when #after_update_path_for' do
       it 'redirects to the current user dashboard' do
-        put admin_registration_path, @params
+        put admin_registration_path, params: { admin: { password: 'admin123',
+                                                        password_confirmation: 'admin123',
+                                                        current_password: '1234567890' } }
         expect(response).to redirect_to admin_dashboard_path
       end
     end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Registrations', type: :request do
+  describe 'Student registration' do
+    let(:student) { create(:student) }
+
+    setup do
+      sign_in student
+      @params = { params: { student: { password: 'test123',
+                                       password_confirmation: 'test123',
+                                       current_password: 'zeliotest' } } }
+    end
+
+    it 'checks if the password was updated' do
+      put student_registration_path, @params
+      student.reload
+      expect(student.valid_password?('test123')).to be(true)
+    end
+
+    context '#after_update_path_for' do
+      it 'redirects to the current user dashboard' do
+        put student_registration_path, @params
+        expect(response).to redirect_to student_dashboard_path
+      end
+    end
+
+    context 'when edit password fail' do
+      it 'redirects to edit template' do
+        put student_registration_path, params: { student: { passsword: '2323',
+                                                            password_confirmation: '2222',
+                                                            current_password: 'saddsdsa',
+                                                            email: 'x@x.com' } }
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  describe 'Admin registration' do
+    let(:admin) { create(:admin) }
+
+    setup do
+      sign_in admin
+      @params = { params: { admin: { password: 'admin123',
+                                     password_confirmation: 'admin123',
+                                     current_password: '1234567890' } } }
+    end
+
+    it 'checks if the password was updated' do
+      put admin_registration_path, @params
+      admin.reload
+      expect(admin.valid_password?('admin123')).to be(true)
+    end
+
+    context '#after_update_path_for' do
+      it 'redirects to the current user dashboard' do
+        put admin_registration_path, @params
+        expect(response).to redirect_to admin_dashboard_path
+      end
+    end
+
+    context 'when edit password fail' do
+      it 'redirects to edit template' do
+        put admin_registration_path, params: { admin: { passsword: '2323',
+                                                        password_confirmation: '2222',
+                                                        current_password: 'saddsdsa',
+                                                        email: 'x@x.com' } }
+        expect(response).to render_template :edit
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR creates a link on the top-right menu to change password then an edit page will be showed to update the password. The student and admins are allowed to use this link.

### Changelog
- create a devise registration controller
- customize devise edit view
- customize devise errors messages
- add on the top-right menu a link to edit password
- add a flash message on the internal layout
- add devise i18n for student and admin
- add devise registration routes for student and admin
- create registrations specs

### How to test
First, you must log in as a student or admin, secondly hit on your name on the top-right of the page and after clicking on change password link. 
On the change password screen, you need to fill it up with the following information: password, password confirmation, and your current password then click it on the save button.

### Screenshots

Top-right menu
![image](https://user-images.githubusercontent.com/104600/67626929-48c92480-f829-11e9-90fa-9e01bf02baca.png)

Change Password View
![image](https://user-images.githubusercontent.com/104600/67626915-e4a66080-f828-11e9-85cc-0745d23b7c79.png)

Error message
![image](https://user-images.githubusercontent.com/104600/67626910-d0fafa00-f828-11e9-8f92-93217e2661ed.png)
