### PR TITLE
setup production env to use only ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
### Description

This PR is setting up the production env to use SSL.

### Changelog
- Generate the certificates
- Add SSL on Heroku server
- Send the certificates to Heroku server
- Add config.force_ssl as true on the production env file

### How to test
It can be checked through the terminal -> curl -vI https://zelio.aguasdearuanda.org.br.
Also, check it out after deploying on production if the Zelio URL is redirecting to https.
